### PR TITLE
セッションとワークショップのアーカイブページを追加・devnavbarを修正

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,4 +1,4 @@
-<!--<header>
+<header>
   <nav class="menu">
     <input type="checkbox" id="menu-check">
     <label for="menu-check" class="menu-hamburger"><img src="{{site.url}}/img/svg/bars.svg" alt="メニュー" class="menu-bars"><img src="{{site.url}}/img/svg/close.svg" alt="閉じる" class="menu-close"></label>
@@ -17,8 +17,8 @@
         <li><a href="{{site.url}}/session">セッション</a></li>
         <li><a href="{{site.url}}/workshop">ワークショップ</a></li>
       </ul></li>
-      <li><a href="{{site.url}}/contests/1">コンテスト</a></li>
+      <li><a href="{{site.url}}/contest">コンテスト</a></li>
       <li><a href="{{site.url}}#contactme">お問い合わせ</a></li>
     </ul>
   </nav>
-</header>-->
+</header>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -12,11 +12,11 @@
         </ul>
       </li>
       <li><a href="{{site.url}}#news">お知らせ</a></li>
-      <li class="menu-first"><a href="{{site.url}}/timetable">タイムテーブル</a>
+      <!--<li class="menu-first"><a href="{{site.url}}/timetable">タイムテーブル</a>
         <ul class="menu-second">
         <li><a href="{{site.url}}/session">セッション</a></li>
         <li><a href="{{site.url}}/workshop">ワークショップ</a></li>
-      </ul></li>
+      </ul></li>-->
       <li><a href="{{site.url}}/contest">コンテスト</a></li>
       <li><a href="{{site.url}}#contactme">お問い合わせ</a></li>
     </ul>

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -120,7 +120,7 @@
             padding: 4vw;
             flex: 0 0 120px;
             margin: 6px 8px;
-            min-width: 70%;
+            min-width: 86%;
             width: calc(100% - 8vw);
 
             .article-thumbnail {

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -48,3 +48,88 @@
   padding: 4px 24px;
 }
 
+//セッション、ワークショップの記事一覧
+.post-content {
+    .article {
+        background-color: #fff;
+        border-radius: 6px;
+        box-shadow: 0px 0px 12px rgba($gray, 0.3);
+        float: left; //横並び
+        margin: 12px 8px;
+        text-align: left;
+
+        a {
+            text-decoration: none; //外部リンクの下線消す
+        }
+    }
+
+    .article-date {
+        font-weight: bold;
+        margin-bottom: 4px;
+    }
+
+    //ワークショップの記事一覧
+    .article-event {
+        padding: 2vw;
+        width: calc(50% - 4vw - 16px); //1行に2記事入るようにする
+
+        .article-thumbnail {
+            height: calc(((80vw / 2) - 4vw - 16px) * (400 / 600)); //縦横比率が2:3になるように設定
+            max-height: calc(((800px / 2) - 40px - 16px) * (400 / 600));
+        }
+    }
+
+    //ワークショップのタグ一覧
+    .tag-workshop {
+        background: linear-gradient(transparent 70%, $light-blue 70%);
+    }
+
+    //セッションの記事一覧
+    .article-session {
+        padding: 2vw;
+        width: calc(50% - 4vw - 16px);
+
+        .article-thumbnail {
+            height: auto !important;
+        }
+    }
+
+    //セッションのカテゴリ
+    .session-tag {
+        background-color: $light-gray;
+        margin-bottom: 8px;
+        padding: 12px;
+        text-align: center;
+    }
+
+    //記事のサムネイル画像
+    .article-thumbnail {
+        border-radius: 4px;
+        object-fit: cover;
+        width: 100%;
+    }
+
+    //記事のタイトル
+    .article-title {
+        margin-top: 4px;
+    }
+
+    //画面幅800px以下のときに記事一覧の一つ一つを幅いっぱい表示する(レスポンシブ対応)
+    @media screen and (max-width: 800px) {
+        .article {
+            padding: 4vw;
+            flex: 0 0 120px;
+            margin: 6px 8px;
+            min-width: 70%;
+            width: calc(100% - 8vw);
+
+            .article-thumbnail {
+                height: calc(((80vw / 1.5) - 2vw) * (400 / 600));
+            }
+        }
+
+        .article-news .article-title {
+            height: auto;
+        }
+    }
+}

--- a/session.md
+++ b/session.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "セッション"
+---
+<div class="flex">
+{% for post in site.categories.session %}
+  {% include sessions.html %}
+{% endfor %}
+</div>

--- a/session.md
+++ b/session.md
@@ -2,6 +2,7 @@
 layout: post
 title: "セッション"
 ---
+<p>現在作成中です！</p>
 <div class="flex">
 {% for post in site.categories.session %}
   {% include sessions.html %}

--- a/timetable.md
+++ b/timetable.md
@@ -2,7 +2,8 @@
 layout: post
 title: "タイムテーブル"
 ---
-<img src="{{site.url}}/img/timetable.png" alt="タイムテーブル" style="width: 100%;">
+<p>現在作成中です！</p>
+<!--img src="{{site.url}}/img/timetable.png" alt="タイムテーブル" style="width: 100%;"-->
 
 <!--
   <div class="table">

--- a/timetable.md
+++ b/timetable.md
@@ -1,0 +1,67 @@
+---
+layout: post
+title: "タイムテーブル"
+---
+<img src="{{site.url}}/img/timetable.png" alt="タイムテーブル" style="width: 100%;">
+
+<!--
+  <div class="table">
+    <h2 class="table-timehead">時間</h2>
+    <input type="radio" id="radio-session" name="tab_item" checked>
+    <label for="radio-session"><h2 class="table-head">セッション</h2></label>
+    <input type="radio" id="radio-workshop" name="tab_item">
+    <label for="radio-workshop"><h2 class="table-head">ワークショップ</h2></label>
+
+    <div class="table-column table-time">
+    <ol>
+      <li>10:00</li>
+      <li>10:30</li>
+      <li>11:00</li>
+      <li>11:30</li>
+      <li>12:00</li>
+      <li>12:30</li>
+      <li>13:00</li>
+      <li>13:30</li>
+      <li>14:00</li>
+      <li>14:30</li>
+      <li>15:00</li>
+      <li>15:30</li>
+      <li>16:00</li>
+      <li>16:30</li>
+      <li>17:00</li>
+      <li>17:30</li>
+      <li>18:00</li>
+    </ol>
+    </div>
+    <div class="table-column table-session table-content">
+    <ol>
+      {% for session in site.data.sessions %}
+      <li style="height: calc(({{session.etime}} - {{session.stime}}) * 8px - 20px - 8px); top: calc({{session.stime | minus: 600.0}} * 8px);">
+        <div class="session-tag">
+          {{session.tag}}
+        </div>
+        {%if session.url %}<a href="{{session.url}}">{% endif %}
+        <h3>{{session.title}}</h3>
+        {%if session.url %}</a>{% endif %}
+        <p>[{{session.stime | floor | divided_by: 60 }}:{{session.stime | floor | modulo: 60}}-{{session.etime | floor | divided_by: 60 }}:{{session.etime | floor | modulo: 60}}] {{session.speaker}}</p>
+      </li>
+      {% endfor %}
+    </ol>
+    </div>
+    <div class="table-column table-workshop table-content">
+    <ol>
+      {% for workshop in site.data.workshops %}
+      <li style="height: calc(({{workshop.etime}} - {{workshop.stime}}) * 8px - 20px - 8px); top: calc({{workshop.stime | minus: 600.0}} * 8px); left: calc({{workshop.column}} * (33.33% + 8px));">
+        {%if workshop.url %}<a href="{{workshop.url}}">{% endif %}
+        <h3>{{workshop.title}}</h3>
+        {%if workshop.url %}</a>{% endif %}
+        <p>[{{workshop.stime | floor | divided_by: 60 }}:{{workshop.stime | floor | modulo: 60}}-{{workshop.etime | floor | divided_by: 60 }}:{{workshop.etime | floor | modulo: 60}}] {{workshop.speaker}}</p>
+        {% for tag in workshop.tag %}
+          <span class="tag-workshop">{{tag}}</span>
+        {% endfor %}
+      </li>
+      {% endfor %}
+    </ol>
+    </div>
+  </div>
+-->

--- a/workshop.md
+++ b/workshop.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "ワークショップ"
+---
+<div class="flex">
+{% for post in site.categories.workshop %}
+  {% include workshops.html %}
+{% endfor %}
+</div>

--- a/workshop.md
+++ b/workshop.md
@@ -2,6 +2,7 @@
 layout: post
 title: "ワークショップ"
 ---
+<p>現在作成中です！</p>
 <div class="flex">
 {% for post in site.categories.workshop %}
   {% include workshops.html %}


### PR DESCRIPTION
ほぼ昨年からのコピーですが、セッションとワークショップのアーカイブページを追加し、それに合わせてnavbarを修正しました。
各個別ページのレイアウトと原稿自体がまだなので、navbarから「タイムテーブル」「セッション」「ワークショップ」のリンクは一旦非表示にしています。