### PR TITLE
Update description on DojoCon

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@ copy: "- Beyond the distance(距離を超えて) -"
       <h2>DojoCon Japan 2020</h2>
       <div class="text">
         <h3>日本最大の CoderDojo の祭典</h3>
-        <p>DojoCon Japan とは CoderDojo コミュニティが全国から集まる、年に１度のカンファレンスイベントです。</p>
-        <p>CoderDojo 発祥の地アイルランドでは、CoderDojo Foundation主催の DojoCon (CoderDojo Conference) が年１回のペースで開催されています。「DojoCon Japan」はこの日本版という位置づけで、2016年〜2017年は大阪、2018年は東京、2019年は名古屋で開催されました。本年は5回目の開催をオンラインで行います。DojoCon は、主に CoderDojo を支える運営者やメンターたちを対象にしたカンファレンスであり、CoderDojo の運営方法やノウハウの共有などに主眼が置かれています。</p>
+        <p>DojoCon とは CoderDojo コミュニティが全国から集まる、年に１度のカンファレンスイベント (CoderDojo Conference) です。</p>
+        <p>「DojoCon Japan」はこの日本版という位置づけで、2016年〜2017年は大阪、2018年は東京、2019年は名古屋で開催されました。本年は5回目の開催をオンラインで行います。DojoCon は、主に CoderDojo を支える運営者やメンターたちを対象にしたカンファレンスであり、CoderDojo の運営方法やノウハウの共有などに主眼が置かれています。</p>
       </div>
     
       <div class="text">


### PR DESCRIPTION
@kiriem @ymsg19 @koichi0702 

「DojoCon」の説明として、「CoderDojo Foundation 主催」といった文章がありますが、

> CoderDojo 発祥の地アイルランドでは、CoderDojo Foundation主催の DojoCon (CoderDojo Conference) が年１回のペースで開催されています。

こちら２〜３年前あたりから CoderDojo Foundation は主催ではなくなったかなと記憶していますので、その部分の説明文を一部変更してみました！ :eyes: ✅ 後ほどご確認していただけると幸いです (＞人＜ )✨（ちなみに [Coolest Projects](https://online.coolestprojects.org/) は引き続き主催の一部として参画）


> **DojoCons are community-led CoderDojo conferences** specifically tailored to volunteers from the worldwide CoderDojo movement. Every year, the international conference is run by a different group of volunteers from one or more Dojos, and some volunteers also organise regional, smaller-scale DojoCons

![DojoCon Handbook](https://user-images.githubusercontent.com/155807/100290743-6aae5100-2fbf-11eb-88df-c5b972b2a000.png)

cf. https://help.coderdojo.com/hc/en-us/articles/360018873572-DojoCon-Handbook

