### PR TITLE
ワークショップ申し込み方法表示のif文修正

### DIFF
--- a/workshop.html
+++ b/workshop.html
@@ -23,7 +23,7 @@ thumbnail: workshop.png
             <p>
                 {% if data.badge == 'must' %}
                 <span class="badge badge-must">申し込み必須</span> 
-                {% else if data.badge == 'double' %}
+                {% elsif data.badge == 'double' %}
                 <span class="badge badge-must">事前・当日申し込み必須</span>
 
                 {% else %}


### PR DESCRIPTION
ワークショップのbadgeが"none"の場合でも「事前・当日申し込み必須」と表示されてしまう問題を修正しました。

### before
![image](https://user-images.githubusercontent.com/31533303/101485092-ffd91e80-399d-11eb-8489-3f2956fc5680.png)

### after
![image](https://user-images.githubusercontent.com/31533303/101485150-17b0a280-399e-11eb-8b0d-db34660c354d.png)
