### PR TITLE
ワークショップページの「ドット絵おえかき」のタイトルと文言を修正

### DIFF
--- a/_data/workshop.yml
+++ b/_data/workshop.yml
@@ -19,10 +19,10 @@
   limit: 8
   url: https://dojocon-japan.doorkeeper.jp/events/114695
 
-- title: ドット絵おえかき
+- title: みんなで合作！スプレッドシートでドット絵おえかき体験
   badge: double
   time: 13:00-16:30 
-  text: Google スプレッドシートを使ったピクセルアート体験です。好きな時間に好きなだけ熱中して、みなさんの手でスプレッドシートを楽しく彩ってください♪<br>※当日飛び込み参加については別途ご案内
+  text: Google スプレッドシートを使った平面（２次元）のピクセルアート（ドット絵）体験会です。<br>好きな時間に好きなだけ熱中して、みなさんの手でスプレッドシートを楽しく彩ってください♪<br>※当日飛び込み参加については別途ご案内
   limit: 30
   url: https://dojocon-japan.doorkeeper.jp/events/114698
 


### PR DESCRIPTION
モブプロの文言修正（アクセス数調整）に少し便乗して、ドット絵WSの文言も修正しました。