### PR TITLE
【修正】TOPページの YouTube Live をアーカイブに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,33 +89,16 @@ copy: "- Beyond the Distance(距離を超えて) -"
 
     </div>
 
-    <!--
     <div class="container">
-      <div class="row">
-    	<div class="col-md-8 offset-md-2">
-          <h2 class="text-center title-text">配信中のライブはこちら！</h2>
-          <p class="text-center caption">メイントラック午後の部</p>
-          <p class="text-center caption">2020/12/27 13:00～18:00</p>
-	</div>
-
-	<div class="col-md-8 offset-md-2 p-3">
-          <iframe width="100%" height="400" src="https://www.youtube-nocookie.com/embed/4sJRhuidZ98" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-	</div>
-      </div>
-      
-    </div>
-    -->
-
-    <div class="row my-5">
-
-      <div class="col-md-6 offset-md-3 col-12">
-        <div class="text-center">
-          <a href="https://dojocon-japan.doorkeeper.jp/events/114635" class="btn btn-main"><i class="fas fa-user-plus"></i> チケットを申し込む</a>
+        <div class="row">
+            <div class="col-md-8 offset-md-2 mb-5">
+                <h2 class="text-center title-text">今年のDojoCon Japan は終了しました！！</h2>
+                <h4 class="text-center title-text mt-0">当日のアーカイブはこちら！</h4>
+            <a href="https://www.youtube.com/playlist?list=PL_XgRvFvKBPZOwlkFq89AzWYsyp8tMD4s"  class="button" target="_blank" rel="noopener">Youtubeプレイリストを開く</a>
         </div>
-      </div>
-
+            </div>
+        </div>
     </div>
-  </div>
 
   <div class="container-fruid">
     <section id="news" class="section-gray">


### PR DESCRIPTION
### 変更点
- TOPの YouTube Live をアーカイブに変更
- TOPの 申し込みフォームを削除

Before
![image](https://user-images.githubusercontent.com/74172007/103206746-e3e2f000-493f-11eb-8e5d-715abbcc31da.png)


After
![image](https://user-images.githubusercontent.com/74172007/103206699-ce6dc600-493f-11eb-9c95-599efe304868.png)
